### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Set scanBuiltinModules, scanDevDependencies and scanFileModules to false to disa
   "node-module-intellisense.scanFileModules": true,
 
   /**
-   * Scans alternative module paths (eg. Search on ${workspcaceRoot}/lib).
+   * Scans alternative module paths (eg. Search on ${workspaceFolder}/lib).
    * Useful when using packages like (https://www.npmjs.com/package/app-module-path) to manage require paths folder.
    **/
   "node-module-intellisense.modulePaths": [],


### PR DESCRIPTION
Hi,
PR to fix the typo in the README.md.
Also replaced "root" by "folder" due to https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented
Thank you for the extension!